### PR TITLE
Fix PHP 8.1 http_build_query() deprecation "http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated"

### DIFF
--- a/src/Facebook/Url/FacebookUrlManipulator.php
+++ b/src/Facebook/Url/FacebookUrlManipulator.php
@@ -81,7 +81,7 @@ class FacebookUrlManipulator
         }
 
         if (strpos($url, '?') === false) {
-            return $url . '?' . http_build_query($newParams, null, '&');
+            return $url . '?' . http_build_query($newParams, '', '&');
         }
 
         list($path, $query) = explode('?', $url, 2);
@@ -94,7 +94,7 @@ class FacebookUrlManipulator
         // Sort for a predicable order
         ksort($newParams);
 
-        return $path . '?' . http_build_query($newParams, null, '&');
+        return $path . '?' . http_build_query($newParams, '', '&');
     }
 
     /**


### PR DESCRIPTION
The new default value for that param is an empty string.